### PR TITLE
Align make_lai forest type indices with makeFOREST

### DIFF
--- a/make_lai.m
+++ b/make_lai.m
@@ -1,14 +1,14 @@
 function lai=make_lai(type, dateval)
 %input: forest type raster where
-% 1 coniferous
-% 2 deciduous 
-% dateval, matlab datetime
+% 1 deciduous
+% 2 coniferous
+% dateval, MATLAB datenum
 
 %output lai: leaf area index for two veg types
 
 %type
 vlai_summer=[2.5 2.5];
-vlai_winter=[2.5 0.5];
+vlai_winter=[0.5 2.5];
 
 % Note: A maximum forest LAI of 5.0 will give almost zero (like
 % 10 W m^2) incoming solar under the canopy.  Values for Fraser


### PR DESCRIPTION
makeFOREST uses type 1 for deciduous forest and type 2 for coniferous forest, but make_lai expected the reverse. Since topo_winds passes FOREST.type.num_val directly to make_lai, winter LAI was assigned to the wrong forest type.

This sets vlai_winter to [0.5 2.5] to match makeFOREST and corrects the input comments. Summer values are unchanged because both forest types use an LAI of 2.5.